### PR TITLE
Added a definition reset step to our object, field and index migration steps

### DIFF
--- a/handlers/information-field.js
+++ b/handlers/information-field.js
@@ -44,7 +44,7 @@ module.exports = {
     * @param {fn} cb
     *        a node style callback(err, results) to send data when job is finished
     */
-   fn: function handler(req, cb) {
+   fn: function handler(req, cb, manualReset = false) {
       req.log("definition_manager.information-field:");
 
       // get the AB for the current tenant
@@ -55,16 +55,28 @@ module.exports = {
 
             const object = AB.objectByID(objID);
             if (!object) {
-               const err = new Error(`ABObject not found for [${objID}]`);
-               err.code = 404;
-               return cb(err);
+               if (manualReset) {
+                  const err = new Error(`ABObject not found for [${objID}]`);
+                  err.code = 404;
+                  return cb(err);
+               }
+               // attempt a single manual Reset of the definitions:
+               req.log("::: MANUAL RESET DEFINITIONS :::");
+               ABBootstrap.resetDefinitions(req);
+               return handler(req, cb, true);
             }
 
             const field = object.fieldByID(fieldID);
             if (!field) {
-               const err = new Error(`ABField not found for [${fieldID}]`);
-               err.code = 404;
-               return cb(err);
+               if (manualReset) {
+                  const err = new Error(`ABField not found for [${fieldID}]`);
+                  err.code = 404;
+                  return cb(err);
+               }
+               // attempt a single manual Reset of the definitions:
+               req.log("::: MANUAL RESET DEFINITIONS :::");
+               ABBootstrap.resetDefinitions(req);
+               return handler(req, cb, true);
             }
 
             const dbConn = AB.Knex.connection();

--- a/handlers/information-object.js
+++ b/handlers/information-object.js
@@ -43,7 +43,7 @@ module.exports = {
     * @param {fn} cb
     *        a node style callback(err, results) to send data when job is finished
     */
-   fn: function handler(req, cb) {
+   fn: function handler(req, cb, manualReset = false) {
       req.log("definition_manager.information-object:");
 
       // get the AB for the current tenant
@@ -52,9 +52,15 @@ module.exports = {
             const objID = req.param("ID");
             const object = AB.objectByID(objID);
             if (!object) {
-               const err = new Error(`ABObject not found for [${objID}]`);
-               err.code = 404;
-               return cb(err);
+               if (manualReset) {
+                  const err = new Error(`ABObject not found for [${objID}]`);
+                  err.code = 404;
+                  return cb(err);
+               }
+               // attempt a single manual Reset of the definitions:
+               req.log("::: MANUAL RESET DEFINITIONS :::");
+               ABBootstrap.resetDefinitions(req);
+               return handler(req, cb, true);
             }
 
             const dbConn = AB.Knex.connection();

--- a/handlers/migrate-field-create.js
+++ b/handlers/migrate-field-create.js
@@ -47,26 +47,39 @@ module.exports = {
     * @param {fn} cb
     *        a node style callback(err, results) to send data when job is finished
     */
-   fn: function handler(req, cb) {
+   fn: function handler(req, cb, manualReset = false) {
       req.log("definition_manager.migrate-field-create:");
 
       // get the AB for the current tenant
       ABBootstrap.init(req)
-         .then(async (AB) => { // eslint-disable-line
+         .then(async (AB) => {
+            // eslint-disable-line
             var objID = req.param("objID");
             var object = AB.objectByID(objID);
             if (!object) {
-               var err1 = new Error(`ABObject not found for [${objID}]`);
-               err1.code = 403;
-               return cb(err1);
+               if (manualReset) {
+                  var err1 = new Error(`ABObject not found for [${objID}]`);
+                  err1.code = 403;
+                  return cb(err1);
+               }
+               // attempt a single manual Reset of the definitions:
+               req.log("::: MANUAL RESET DEFINITIONS :::");
+               ABBootstrap.resetDefinitions(req);
+               return handler(req, cb, true);
             }
 
             var id = req.param("ID");
             var field = object.fieldByID(id);
             if (!field) {
-               var err2 = new Error(`ABField not found for [${id}]`);
-               err2.code = 403;
-               return cb(err2);
+               if (manualReset) {
+                  var err2 = new Error(`ABField not found for [${id}]`);
+                  err2.code = 403;
+                  return cb(err2);
+               }
+               // attempt a single manual Reset of the definitions:
+               req.log("::: MANUAL RESET DEFINITIONS :::");
+               ABBootstrap.resetDefinitions(req);
+               return handler(req, cb, true);
             }
 
             try {

--- a/handlers/migrate-field-down.js
+++ b/handlers/migrate-field-down.js
@@ -47,7 +47,7 @@ module.exports = {
     * @param {fn} cb
     *        a node style callback(err, results) to send data when job is finished
     */
-   fn: function handler(req, cb) {
+   fn: function handler(req, cb, manualReset = false) {
       req.log("definition_manager.migrate-field-down:");
 
       // get the AB for the current tenant
@@ -56,17 +56,29 @@ module.exports = {
             var objID = req.param("objID");
             var object = AB.objectByID(objID);
             if (!object) {
-               var err1 = new Error(`ABObject not found for [${objID}]`);
-               err1.code = 403;
-               return cb(err1);
+               if (manualReset) {
+                  var err1 = new Error(`ABObject not found for [${objID}]`);
+                  err1.code = 403;
+                  return cb(err1);
+               }
+               // attempt a single manual Reset of the definitions:
+               req.log("::: MANUAL RESET DEFINITIONS :::");
+               ABBootstrap.resetDefinitions(req);
+               return handler(req, cb, true);
             }
 
             var id = req.param("ID");
             var field = object.fieldByID(id);
             if (!field) {
-               var err2 = new Error(`ABField not found for [${id}]`);
-               err2.code = 403;
-               return cb(err2);
+               if (manualReset) {
+                  var err2 = new Error(`ABField not found for [${id}]`);
+                  err2.code = 403;
+                  return cb(err2);
+               }
+               // attempt a single manual Reset of the definitions:
+               req.log("::: MANUAL RESET DEFINITIONS :::");
+               ABBootstrap.resetDefinitions(req);
+               return handler(req, cb, true);
             }
 
             try {

--- a/handlers/migrate-field-update.js
+++ b/handlers/migrate-field-update.js
@@ -47,7 +47,7 @@ module.exports = {
     * @param {fn} cb
     *        a node style callback(err, results) to send data when job is finished
     */
-   fn: function handler(req, cb) {
+   fn: function handler(req, cb, manualReset = false) {
       req.log("definition_manager.migrate-field-update:");
 
       // get the AB for the current tenant
@@ -56,9 +56,15 @@ module.exports = {
             var objID = req.param("objID");
             var object = AB.objectByID(objID);
             if (!object) {
-               var err1 = new Error(`ABObject not found for [${objID}]`);
-               err1.code = 403;
-               return cb(err1);
+               if (manualReset) {
+                  var err1 = new Error(`ABObject not found for [${objID}]`);
+                  err1.code = 403;
+                  return cb(err1);
+               }
+               // attempt a single manual Reset of the definitions:
+               req.log("::: MANUAL RESET DEFINITIONS :::");
+               ABBootstrap.resetDefinitions(req);
+               return handler(req, cb, true);
             }
 
             // we don't perform these for API based objects:
@@ -69,9 +75,15 @@ module.exports = {
             var id = req.param("ID");
             var field = object.fieldByID(id);
             if (!field) {
-               var err2 = new Error(`ABField not found for [${id}]`);
-               err2.code = 403;
-               return cb(err2);
+               if (manualReset) {
+                  var err2 = new Error(`ABField not found for [${id}]`);
+                  err2.code = 403;
+                  return cb(err2);
+               }
+               // attempt a single manual Reset of the definitions:
+               req.log("::: MANUAL RESET DEFINITIONS :::");
+               ABBootstrap.resetDefinitions(req);
+               return handler(req, cb, true);
             }
 
             try {

--- a/handlers/migrate-index-create.js
+++ b/handlers/migrate-index-create.js
@@ -47,7 +47,7 @@ module.exports = {
     * @param {fn} cb
     *        a node style callback(err, results) to send data when job is finished
     */
-   fn: function handler(req, cb) {
+   fn: function handler(req, cb, manualReset = false) {
       req.log("definition_manager.migrate-index-create:");
 
       // get the AB for the current tenant
@@ -56,17 +56,29 @@ module.exports = {
             var objID = req.param("objID");
             var object = AB.objectByID(objID);
             if (!object) {
-               var err1 = new Error(`ABObject not found for [${objID}]`);
-               err1.code = 403;
-               return cb(err1);
+               if (manualReset) {
+                  var err1 = new Error(`ABObject not found for [${objID}]`);
+                  err1.code = 403;
+                  return cb(err1);
+               }
+               // attempt a single manual Reset of the definitions:
+               req.log("::: MANUAL RESET DEFINITIONS :::");
+               ABBootstrap.resetDefinitions(req);
+               return handler(req, cb, true);
             }
 
             var id = req.param("ID");
             var index = object.indexByID(id);
             if (!index) {
-               var err2 = new Error(`ABIndex not found for [${id}]`);
-               err2.code = 403;
-               return cb(err2);
+               if (manualReset) {
+                  var err2 = new Error(`ABIndex not found for [${id}]`);
+                  err2.code = 403;
+                  return cb(err2);
+               }
+               // attempt a single manual Reset of the definitions:
+               req.log("::: MANUAL RESET DEFINITIONS :::");
+               ABBootstrap.resetDefinitions(req);
+               return handler(req, cb, true);
             }
 
             try {

--- a/handlers/migrate-index-delete.js
+++ b/handlers/migrate-index-delete.js
@@ -47,7 +47,7 @@ module.exports = {
     * @param {fn} cb
     *        a node style callback(err, results) to send data when job is finished
     */
-   fn: function handler(req, cb) {
+   fn: function handler(req, cb, manualReset = false) {
       req.log("definition_manager.migrate-index-delete:");
 
       // get the AB for the current tenant
@@ -56,17 +56,29 @@ module.exports = {
             var objID = req.param("objID");
             var object = AB.objectByID(objID);
             if (!object) {
-               var err1 = new Error(`ABObject not found for [${objID}]`);
-               err1.code = 403;
-               return cb(err1);
+               if (manualReset) {
+                  var err1 = new Error(`ABObject not found for [${objID}]`);
+                  err1.code = 403;
+                  return cb(err1);
+               }
+               // attempt a single manual Reset of the definitions:
+               req.log("::: MANUAL RESET DEFINITIONS :::");
+               ABBootstrap.resetDefinitions(req);
+               return handler(req, cb, true);
             }
 
             var id = req.param("ID");
             var index = object.indexByID(id);
             if (!index) {
-               var err2 = new Error(`ABIndex not found for [${id}]`);
-               err2.code = 403;
-               return cb(err2);
+               if (manualReset) {
+                  var err2 = new Error(`ABIndex not found for [${id}]`);
+                  err2.code = 403;
+                  return cb(err2);
+               }
+               // attempt a single manual Reset of the definitions:
+               req.log("::: MANUAL RESET DEFINITIONS :::");
+               ABBootstrap.resetDefinitions(req);
+               return handler(req, cb, true);
             }
 
             try {

--- a/handlers/migrate-object-create.js
+++ b/handlers/migrate-object-create.js
@@ -46,23 +46,32 @@ module.exports = {
     * @param {fn} cb
     *        a node style callback(err, results) to send data when job is finished
     */
-   fn: function handler(req, cb) {
+   fn: function handler(req, cb, manualReset = false) {
       req.log("definition_manager.migrate-object-create:");
 
       // get the AB for the current tenant
       ABBootstrap.init(req)
-         .then(async (AB) => { // eslint-disable-line
-
+         .then(async (AB) => {
             var id = req.param("ID");
             var object = AB.objectByID(id);
             if (!object) {
                object = AB.queryByID(id);
             }
+
             if (!object) {
-               var err = new Error(`ABObject not found for [${id}]`);
-               err.code = 403;
-               return cb(err);
+               if (manualReset) {
+                  var err = new Error(`ABObject not found for [${id}]`);
+                  err.code = 403;
+                  err.context =
+                     "Service:definition_manager.migrate-object-create: Error initializing ABFactory";
+                  return cb(err);
+               }
+               // attempt a single manual Reset of the definitions:
+               req.log("::: MANUAL RESET DEFINITIONS :::");
+               ABBootstrap.resetDefinitions(req);
+               return handler(req, cb, true);
             }
+
             try {
                await object.migrateCreate(req);
                cb(null, { status: "success" });

--- a/handlers/migrate-object-down.js
+++ b/handlers/migrate-object-down.js
@@ -46,7 +46,7 @@ module.exports = {
     * @param {fn} cb
     *        a node style callback(err, results) to send data when job is finished
     */
-   fn: function handler(req, cb) {
+   fn: function handler(req, cb, manualReset = false) {
       req.log("definition_manager.migrate-object-down:");
 
       // get the AB for the current tenant
@@ -55,9 +55,15 @@ module.exports = {
             var id = req.param("ID");
             var object = AB.objectByID(id);
             if (!object) {
-               var err = new Error(`ABObject not found for [${id}]`);
-               err.code = 403;
-               return cb(err);
+               if (manualReset) {
+                  var err = new Error(`ABObject not found for [${id}]`);
+                  err.code = 403;
+                  return cb(err);
+               }
+               // attempt a single manual Reset of the definitions:
+               req.log("::: MANUAL RESET DEFINITIONS :::");
+               ABBootstrap.resetDefinitions(req);
+               return handler(req, cb, true);
             }
             try {
                await object.migrateDrop(req);

--- a/handlers/plugin-add.js
+++ b/handlers/plugin-add.js
@@ -52,7 +52,7 @@ module.exports = {
 
       // get the AB for the current tenant
       try {
-         let AB = await ABBootstrap.init(req); // eslint-disable-line no-unused-vars
+         let AB = await ABBootstrap.init(req);
 
          let urlInput = req.param("url");
          let manifestUrl;
@@ -83,7 +83,7 @@ module.exports = {
 
                if (pathParts.length < 2) {
                   throw new Error(
-                     "Invalid GitHub URL format. Expected: https://github.com/owner/repo"
+                     "Invalid GitHub URL format. Expected: https://github.com/owner/repo",
                   );
                }
 
@@ -101,7 +101,7 @@ module.exports = {
                req.log(`Treating as GitHub URL, fetching from: ${manifestUrl}`);
             } catch (urlError) {
                throw new Error(
-                  `Failed to parse GitHub URL: ${urlError.message}`
+                  `Failed to parse GitHub URL: ${urlError.message}`,
                );
             }
          }
@@ -112,7 +112,7 @@ module.exports = {
 
          if (!response.ok) {
             throw new Error(
-               `Failed to fetch manifest.json (${manifestUrl}): HTTP ${response.status} ${response.statusText}`
+               `Failed to fetch manifest.json (${manifestUrl}): HTTP ${response.status} ${response.statusText}`,
             );
          }
 
@@ -130,7 +130,7 @@ module.exports = {
                   where: {
                      url: manifestUrl,
                   },
-               })
+               }),
             );
 
             let plugin;
@@ -149,8 +149,8 @@ module.exports = {
                         Description: manifest.description,
                         icon: manifest.icon,
                         version: manifest.version,
-                     }
-                  )
+                     },
+                  ),
                );
             } else {
                // Create new plugin
@@ -162,7 +162,7 @@ module.exports = {
                      url: manifestUrl,
                      icon: manifest.icon,
                      version: manifest.version,
-                  })
+                  }),
                );
             }
 
@@ -172,7 +172,7 @@ module.exports = {
                   where: {
                      plugin: plugin.uuid,
                   },
-               })
+               }),
             );
 
             // Create a map of existing links by platform+type for quick lookup
@@ -259,9 +259,9 @@ module.exports = {
                                  url: finalUrl,
                                  platform: pluginEntry.platform,
                                  type: pluginEntry.type,
-                              }
-                           )
-                        )
+                              },
+                           ),
+                        ),
                      );
                   }
                } else {
@@ -274,8 +274,8 @@ module.exports = {
                            url: finalUrl,
                            platform: pluginEntry.platform,
                            type: pluginEntry.type,
-                        })
-                     )
+                        }),
+                     ),
                   );
                }
             }
@@ -289,8 +289,10 @@ module.exports = {
                   req.log(`Removing plugin link: ${linkKey} - not in manifest`);
                   linkOperations.push(
                      req.retry(() =>
-                        PluginLinks.model().destroy({ uuid: existingLink.uuid })
-                     )
+                        PluginLinks.model().destroy({
+                           uuid: existingLink.uuid,
+                        }),
+                     ),
                   );
                }
             }
@@ -305,7 +307,7 @@ module.exports = {
                      uuid: plugin.uuid,
                   },
                   populate: true,
-               })
+               }),
             );
             if (!pluginRecord) {
                throw new Error(`Failed to find plugin record: ${plugin.uuid}`);


### PR DESCRIPTION
When performing an object, field of index migration step, we will now perform a definition reset if we are unable to find the specified definition to work with.